### PR TITLE
Shorten test failure error messages

### DIFF
--- a/vars/getFailureMessage.groovy
+++ b/vars/getFailureMessage.groovy
@@ -73,12 +73,10 @@ def getTestFailures(String log) {
 	}
 
 	if(failuresFound > maxFailureNum) {
-		 failedTestsMessage += "...and " + (failuresFound - maxFailureNum) + " more test failures.</ul>"
-	} else {
-		failedTestsMessage += "</ul>"
+		failedTestsMessage += "...and " + (failuresFound - maxFailureNum) + " more test failures."
 	}
 	
-	failedTestsMessage += "\n\n```\n"
+	failedTestsMessage += "</ul>\n\n```\n"
 	def failedStartPattern = Pattern.compile("Tests run: \\d+,.*(Failures|Errors): [1-9]")
 	def failedStartMatcher = failedStartPattern.matcher(log)
 	if (failedStartMatcher.find()) {

--- a/vars/getFailureMessage.groovy
+++ b/vars/getFailureMessage.groovy
@@ -55,19 +55,27 @@ def formatForJSON(String message) {
 
 def getTestFailures(String log) {
 	def maxStackTraceLength = 500
-	def foundFailures = false
+	def failuresFound = 0
 	def failedTestsMessage = "<h4>Failed Tests:</h4> <ul>"
 	def failedTestPattern = Pattern.compile("[a-z].*<<< (FAILURE|ERROR)!\n")
 	def failedTestMatcher = failedTestPattern.matcher(log)
+	def maxFailureNum = 25
 	while(failedTestMatcher.find()) {
-		foundFailures = true
-		def res = failedTestMatcher.group()
-		failedTestsMessage += "<li>" + res.substring(0, res.indexOf(" Time elapsed")) + "</li>"
+		failuresFound++
+		if(failuresFound <= maxFailureNum) {
+			def res = failedTestMatcher.group()
+			failedTestsMessage += "<li>" + res.substring(0, res.indexOf(" Time elapsed")) + "</li>"
+		}
 	}
-	failedTestsMessage += "</ul>"
 
-	if (!foundFailures) {
+	if (failuresFound == 0) {
 		return ""
+	}
+
+	if(failuresFound > maxFailureNum) {
+		 failedTestsMessage += "...and " + (failuresFound - maxFailureNum) + " more test failures.</ul>"
+	} else {
+		failedTestsMessage += "</ul>"
 	}
 	
 	failedTestsMessage += "\n\n```\n"
@@ -83,7 +91,7 @@ def getTestFailures(String log) {
 def doGenericErrorSearch(String log) {
 	def foundFailure = false
 	def maxStackTraceLength = 500
-	def errorMessage = "Relevant Output: \n\n```\n"
+	def errorMessage = "Potentially Relevant Output: \n\n```\n"
 	def errorPattern = Pattern.compile("(?s)Failures: [1-9]+|(?s)Errors: [1-9]+")
 	def errorMatcher = errorPattern.matcher(log)
 	if (errorMatcher.find()) {


### PR DESCRIPTION
Shorten test failure messages to only show first N test failures (25 at the moment), rather than posting extremely long error messages with 150+ test failures. 

Here is an example of the new test error message output with N set to 5
![Capture](https://user-images.githubusercontent.com/14204943/70642867-3fd7bb00-1bfd-11ea-9b77-71c24715436c.PNG)
