### PR TITLE
Added vars/postReleaseToGithub.groovy

### DIFF
--- a/vars/postReleaseToGithub.groovy
+++ b/vars/postReleaseToGithub.groovy
@@ -1,4 +1,18 @@
 def call(String message, String user, String repository, String credentialsToken, String branch, String tag, String artifactPath) {
+	
+    // Provides a library var to create a Github release and push an artifact up to Github
+    //
+    // This will be done by:
+    // . Add the "github.com/connexta/github-utils-shared-library@master" library to the top of the release job
+    // . Call the var passing the following strings:
+    //   .  path to release notes
+    //   .  repo owner
+    //   .  repo name
+    //   .  ssh key to the github repo
+    //   .  branch
+    //   .  tag
+    //   .  full path to the workspace artifact
+
     script {
             sh """
                 release=\$(curl -XPOST -H "Authorization:token ${credentialsToken}" --data "{\\"tag_name\\": \\"${tag}\\", \\"target_commitish\\": \\"${branch}\\", \\"name\\": \\"${tag}\\", \\"body\\": \\"${message}\\", \\"draft\\": false, \\"prerelease\\": false}" https://api.github.com/repos/${user}/${repository}/releases)

--- a/vars/postReleaseToGithub.groovy
+++ b/vars/postReleaseToGithub.groovy
@@ -1,0 +1,12 @@
+def call(String message, String user, String repository, String credentialsToken, String branch, String tag, String artifactPath) {
+    script {
+            sh """
+                release=\$(curl -XPOST -H "Authorization:token ${credentialsToken}" --data "{\\"tag_name\\": \\"${tag}\\", \\"target_commitish\\": \\"${branch}\\", \\"name\\": \\"${tag}\\", \\"body\\": \\"${message}\\", \\"draft\\": false, \\"prerelease\\": false}" https://api.github.com/repos/${user}/${repository}/releases)
+
+                # Extract the id of the release from the creation response
+                RELEASE_ID=\$(echo "\$release" | sed -n -e 's/"id":\\ \\([0-9]\\+\\),/\\1/p' | head -n 1 | sed 's/[[:blank:]]//g')
+
+                curl -XPOST -H "Authorization:token ${credentialsToken}" -H "Content-Type:application/octet-stream" --data-binary @${artifactPath} https://uploads.github.com/repos/${user}/${repository}/releases/\$RELEASE_ID/assets?name=${tag}.zip
+			"""
+    }
+}


### PR DESCRIPTION
# Created new var to automatically create the release in Github and push artifacts

## What does this PR do?

Provides a library var to create a Github release and push an artifact up to Github

. This will be done by:
. Add the "github.com/connexta/github-utils-shared-library@master library to the top of the release job
. Call the var passing the following strings: 
.. path to release notes
.. repo owner
.. repo name
.. ssh key to the github repo
.. branch
.. tag
.. full path to the workspace artifact

withCredentials([string(credentialsId: 'DDF-Release-Token', variable: 'GITHUB_TOKEN')]) {
                        postReleaseToGithub("Notes: ${notesURL}", "${REPO_OWNER}", "${GITHUB_REPONAME}", "${GITHUB_TOKEN}", "${branch}", "${tag}", "${artifactPath}")
                    }

## Testing
There is a job on Jenkins-test where this has been run and the new trigger enacted
http://jenkins-test.phx.connexta.com/service/jenkins-test/job/release/job/DDFReleaseTonyMorrison/68/
 
## Reviewers
@shaundmorris
@LinkMJB  
@AdamBurstynski 