### PR TITLE
escapeJavaScript message in postCommentIfPR

### DIFF
--- a/vars/postCommentIfPR.groovy
+++ b/vars/postCommentIfPR.groovy
@@ -1,7 +1,9 @@
+import groovy.json.StringEscapeUtils
+
 def call(String message, String user, String repository, String credentialsToken) {
     script {
         if (env.CHANGE_ID != null) {
-            sh "curl -X POST -m 10 -d \'{ \"body\" : \"${message}\" }\' -u ${credentialsToken} https://api.github.com/repos/${user}/${repository}/issues/${CHANGE_ID}/comments"
+            sh "curl -X POST -m 10 -d \'{ \"body\" : \"${StringEscapeUtils.escapeJavaScript(message)}\" }\' -u ${credentialsToken} https://api.github.com/repos/${user}/${repository}/issues/${CHANGE_ID}/comments"
         }
     }
 }


### PR DESCRIPTION
we need to escape quotes and other special characters so that the code doesn't break. e.g. if the message has html in it with `"` the code will break and the call to post the comment will not work